### PR TITLE
Note for Fedora (Installation by Copr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Once the ridiculous amount of dependencies is installed, just run these commands
 	$ ./autogen.sh
 	$ make
 	# make clean install
+	
+**Note :** There is a [copr repository](https://copr.fedoraproject.org/coprs/fnux/GColor3/) for Fedora.	
 
 Translations
 ------------


### PR DESCRIPTION
Add a note to the README in order to redirect the Fedora users to the copr repository.