### PR TITLE
Added Serbian translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -6,4 +6,5 @@ el
 en_GB
 fr
 nl
+sr
 sv

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-09-17 16:31+0200\n"
-"PO-Revision-Date: 2015-09-17 16:35+0200\n"
+"PO-Revision-Date: 2015-09-18 19:05+0200\n"
 "Last-Translator: Марко М. Костић (Marko M. Kostić) "
 "<marko.m.kostic@gmail.com>\n"
 "Language-Team: Serbian\n"
@@ -58,15 +58,15 @@ msgstr "Изађи"
 
 #: ../src/gcolor3-application.c:131
 msgid "Error opening file: "
-msgstr "Грешка приликом отварања датотеке:"
+msgstr "Грешка приликом отварања датотеке: "
 
 #: ../src/gcolor3-application.c:178
 msgid "Error writing file: "
-msgstr "Грешка приликом уписивања у датотеку:"
+msgstr "Грешка приликом уписивања у датотеку: "
 
 #: ../src/gcolor3-window.c:129
 msgid "Error deleting key: "
-msgstr "Грешка приликом брисања кључа:"
+msgstr "Грешка приликом брисања кључа: "
 
 #: ../src/gcolor3-window.c:341
 msgid "Color name..."
@@ -99,4 +99,4 @@ msgstr "Веб страница"
 
 #: ../src/gcolor3-window.c:538
 msgid "Error reading keys: "
-msgstr "Грешка приликом читања кључева:"
+msgstr "Грешка приликом читања кључева: "

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,0 +1,102 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Марко М. Костић (Marko M. Kostić) <marko.m.kostic@gmail.com>, 2015.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-09-17 16:31+0200\n"
+"PO-Revision-Date: 2015-09-17 16:35+0200\n"
+"Last-Translator: Марко М. Костић (Marko M. Kostić) "
+"<marko.m.kostic@gmail.com>\n"
+"Language-Team: Serbian\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
+"10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Virtaal 0.7.1\n"
+
+#: ../data/gcolor3.desktop.in.in.h:1 ../src/main.c:39
+#: ../src/gcolor3-application.c:146
+msgid "Color picker"
+msgstr "Бирач боја"
+
+#: ../data/gcolor3.desktop.in.in.h:2 ../src/gcolor3-window.c:499
+msgid "Choose colors from the picker or the screen"
+msgstr "Изаберите боју из бирача или са екрана"
+
+#. Extra keywords that can be used to search for Gcolor3 in GNOME Shell and Unity
+#: ../data/gcolor3.desktop.in.in.h:4
+msgid "Color;Picker;Palette;"
+msgstr "Боја;Бирач;Палета;Color;Picker;Pallete;Boja:Birač;Paleta"
+
+#: ../src/main.c:45
+msgid "Show the application's version"
+msgstr "Прикажи издање програма"
+
+#: ../src/main.c:56
+msgid "- pick a color from the picker or the screen"
+msgstr "- изабери боју из бирача или са екрана"
+
+#: ../src/main.c:67
+#, c-format
+msgid "Run '%s --help' to see a full list of available command line options"
+msgstr ""
+"Покрените „%s --help“ да бисте видели списак са свим доступним опцијама у "
+"терминалу"
+
+#: ../src/gcolor3-application.c:86
+msgid "About"
+msgstr "О програму"
+
+#: ../src/gcolor3-application.c:87
+msgid "Quit"
+msgstr "Изађи"
+
+#: ../src/gcolor3-application.c:131
+msgid "Error opening file: "
+msgstr "Грешка приликом отварања датотеке:"
+
+#: ../src/gcolor3-application.c:178
+msgid "Error writing file: "
+msgstr "Грешка приликом уписивања у датотеку:"
+
+#: ../src/gcolor3-window.c:129
+msgid "Error deleting key: "
+msgstr "Грешка приликом брисања кључа:"
+
+#: ../src/gcolor3-window.c:341
+msgid "Color name..."
+msgstr "Име боје..."
+
+#: ../src/gcolor3-window.c:364
+msgid "Picker"
+msgstr "Бирач"
+
+#: ../src/gcolor3-window.c:374
+msgid "Saved colors"
+msgstr "Сачуване боје"
+
+#: ../src/gcolor3-window.c:389
+msgid "Color"
+msgstr "Боја"
+
+#: ../src/gcolor3-window.c:404
+msgid "Name"
+msgstr "Име"
+
+#. Translators: translate this to give yourself credits.
+#: ../src/gcolor3-window.c:503
+msgid "translator-credits"
+msgstr "Марко М. Костић (Marko M. Kostić) <marko.m.kostic@gmail.com>"
+
+#: ../src/gcolor3-window.c:504
+msgid "Website"
+msgstr "Веб страница"
+
+#: ../src/gcolor3-window.c:538
+msgid "Error reading keys: "
+msgstr "Грешка приликом читања кључева:"


### PR DESCRIPTION
Tested it out on Fedora 22. Strings are localized properly.
![2015-09-17 16-45-16](https://cloud.githubusercontent.com/assets/4953862/9936305/92e2ae6e-5d5b-11e5-9e5a-0a6b7236a15a.png)
